### PR TITLE
Update Bevy to 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-XX-XX
+
+### Changed
+- Update Bevy to 0.18
+
 ## [0.2.1] - 2025-11-30
 
 ### Added
@@ -40,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InGameClockPlugin` for easy Bevy integration
 - Examples: basic, events, digital_clock
 
+[0.3.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.3.0
 [0.2.1]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.2.1
 [0.2.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.2.0
 [0.1.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-XX-XX
+
+### Changed
+- Update Bevy to 0.19
+
 ## [0.3.0] - 2026-XX-XX
 
 ### Changed
@@ -45,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InGameClockPlugin` for easy Bevy integration
 - Examples: basic, events, digital_clock
 
+[0.4.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.4.0
 [0.3.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.3.0
 [0.2.1]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.2.1
 [0.2.0]: https://github.com/don-matheo/bevy_ingame_clock/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ingame_clock"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Donmatheo <dev@donmatheo.de>"]
 description = "An in-game clock plugin for the Bevy game engine"
@@ -10,14 +10,14 @@ keywords = ["bevy", "game", "clock", "time"]
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.17", default-features = false }
+bevy = { version = "0.18", default-features = false }
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-evalexpr = "12.0"
+evalexpr = "13.1"
 
 [dev-dependencies]
-bevy = "0.17"
-ron = "0.11"
+bevy = "0.18"
+ron = "0.12"
 
 [lib]
 name = "bevy_ingame_clock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ingame_clock"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Donmatheo <dev@donmatheo.de>"]
 description = "An in-game clock plugin for the Bevy game engine"
@@ -10,13 +10,13 @@ keywords = ["bevy", "game", "clock", "time"]
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 evalexpr = "13.1"
 
 [dev-dependencies]
-bevy = "0.18"
+bevy = "0.19"
 ron = "0.12"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin for the [Bevy game engine](https://bevyengine.org) that provides an in-
 
 | Bevy Version | Plugin Version |
 |--------------|----------------|
+| 0.18         | 0.3            |
 | 0.17         | 0.2            |
 
 ## Installation
@@ -28,8 +29,8 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy = "0.17"
-bevy_ingame_clock = "0.2"
+bevy = "0.18"
+bevy_ingame_clock = "0.3"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin for the [Bevy game engine](https://bevyengine.org) that provides an in-
 
 | Bevy Version | Plugin Version |
 |--------------|----------------|
+| 0.19         | 0.4            |
 | 0.18         | 0.3            |
 | 0.17         | 0.2            |
 
@@ -29,8 +30,8 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy = "0.18"
-bevy_ingame_clock = "0.3"
+bevy = "0.19"
+bevy_ingame_clock = "0.4"
 ```
 
 ## Quick Start

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         Text::new("In-game Clock Example\n\nControls:\nSpace: Pause/Resume\n+/-: Double/Halve Speed\n1-6: Set Day Duration\nR: Reset\n\nDate & Time: 0000-00-00 00:00:00"),
         TextFont {
-            font_size: 30.0,
+            font_size: FontSize::Px(30.0),
             ..default()
         },
         TextColor(Color::WHITE),

--- a/examples/digital_clock.rs
+++ b/examples/digital_clock.rs
@@ -66,7 +66,7 @@ fn setup(mut commands: Commands) {
         parent.spawn((
             Text::new(""),
             TextFont {
-                font_size: 100.0,
+                font_size: FontSize::Px(100.0),
                 ..default()
             },
             TextColor(Color::srgb(0.3, 0.8, 0.9)),
@@ -112,7 +112,7 @@ fn setup(mut commands: Commands) {
         parent.spawn((
             Text::new(""),
             TextFont {
-                font_size: 28.0,
+                font_size: FontSize::Px(28.0),
                 ..default()
             },
             TextColor(Color::srgb(0.3, 0.8, 0.9)),
@@ -124,7 +124,7 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         Text::new("Digital Clock\n\nControls:\nSpace: Pause/Resume\n+/-: Speed Up/Down\nR: Reset"),
         TextFont {
-            font_size: 18.0,
+            font_size: FontSize::Px(18.0),
             ..default()
         },
         TextColor(Color::WHITE),
@@ -140,7 +140,7 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         Text::new(""),
         TextFont {
-            font_size: 16.0,
+            font_size: FontSize::Px(16.0),
             ..default()
         },
         TextColor(Color::srgb(0.7, 0.7, 0.7)),

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -64,7 +64,7 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         Text::new("Clock Events Example\n\nControls:\nSpace: Pause/Resume\n+/-: Speed Up/Down\nR: Reset\n1-6: Toggle Events\n\nWatching for events..."),
         TextFont {
-            font_size: 20.0,
+            font_size: FontSize::Px(20.0),
             ..default()
         },
         TextColor(Color::WHITE),


### PR DESCRIPTION
Hello,

I updated the crate to Bevy 0.19. I tested all examples, and they compile and run correctly.

I started from my other PR from Bevy 0.18 that should be merged before: https://github.com/don-matheo/bevy_ingame_clock/pull/5

Feel free to contact me if you need anything.

Note: the release date in the changelog should be updated at release